### PR TITLE
feat: implement profile screen with user data fetching

### DIFF
--- a/mobile/app/(tabs)/profile.tsx
+++ b/mobile/app/(tabs)/profile.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+import { View, Text, Button, StyleSheet, ActivityIndicator, Alert } from 'react-native';
+import { useAuth } from '../../context/AuthContext';
+import { useApi } from '../../services/useApi';
+import usersApi from '../../services/usersApi';
+
+export default function ProfileScreen() {
+  const { logout } = useAuth();
+
+  const { data: user, loading, error, request: loadUser } = useApi(usersApi.getMe);
+
+  useEffect(() => {
+    loadUser();
+  }, []);
+
+  const handleLogout = () => {
+    Alert.alert("Logout", "Are you sure you want to logout?", [
+      { text: "Cancel", style: "cancel" },
+      { text: "OK", onPress: () => logout() }
+    ]);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>My Profile</Text>
+      {loading && <ActivityIndicator size="large" />}
+      {error && <Text style={styles.errorText}>Error: {error}</Text>}
+      
+      {user && (
+        <View style={styles.infoContainer}>
+          <Text style={styles.label}>Email:</Text>
+          <Text style={styles.info}>{user.email}</Text>
+        </View>
+      )}
+      <Button title="Logout" onPress={handleLogout} color="red" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  errorText: {
+    color: 'red',
+    marginVertical: 10,
+  },
+  infoContainer: {
+    marginVertical: 20,
+    alignItems: 'center',
+  },
+  label: {
+    fontSize: 16,
+    color: 'gray',
+  },
+  info: {
+    fontSize: 18,
+    fontWeight: '500',
+    marginTop: 5,
+  },
+});

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -1,9 +1,23 @@
-import { Stack } from 'expo-router';
+import { Tabs } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 
-export default function RootLayout() {
+export default function TabLayout() {
   return (
-    <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-    </Stack>
+    <Tabs>
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color }) => <Ionicons name="home" color={color} size={28} />,
+        }}
+      />
+      <Tabs.Screen
+        name="profile" 
+        options={{
+          title: 'Profile',
+          tabBarIcon: ({ color }) => <Ionicons name="person-circle" color={color} size={28} />,
+        }}
+      />
+    </Tabs>
   );
 }

--- a/mobile/services/usersApi.ts
+++ b/mobile/services/usersApi.ts
@@ -1,10 +1,19 @@
 import apiClient from './apiClient';
 
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
 const getUsers = () => apiClient.get('/users');
 
 const getUserById = (id: number) => apiClient.get(`/users/${id}`);
 
+const getMe = () => apiClient.get<User>('/users/me');
+
 export default {
   getUsers,
   getUserById,
+  getMe,
 };


### PR DESCRIPTION
This PR introduces a protected "Profile" screen that is accessible only to authenticated users. Upon loading, the screen sends an authenticated GET request to the /users/me endpoint to retrieve and display the user's email. The screen also includes a "Logout" button that, when clicked, clears the JWT from secure storage, resets the global authentication state, and redirects the user to the Login screen. This implementation ensures secure access control and proper session management.

closes #84 